### PR TITLE
Hardware equality enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,10 @@ For more info [take a look at the official docs](https://altbeacon.github.io/and
 <br />
 
 ##### Beacons.setHardwareEqualityEnforced(e: boolean): void
-Configures whether a the bluetoothAddress (mac address) must be the same for two Beacons to be configured equal. This setting applies to all beacon instances in the same process. Defaults to false for backward compatibility. Useful when all the beacons you are working with have the same UUID, major and minor (they are only uniquely identifiable by their MAC_ADDRESS), otherwise the module will detect all the beacons as if they were only one.
+Configures whether the bluetoothAddress (mac address) must be the same for two Beacons to be configured equal. This setting applies to all beacon instances in the same process. Defaults to false for backward compatibility.
+<br />
+Useful when all the beacons you are working with have the same UUID, major and minor (they are only uniquely identifiable by their mac address), otherwise the module will detect all the beacons as if they were only one.
+<br />
 For more info [take a look at the official docs](https://altbeacon.github.io/android-beacon-library/javadoc/index.html)
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ For more info [take a look at the official docs](https://altbeacon.github.io/and
 <br />
 <br />
 
+##### Beacons.setHardwareEqualityEnforced(e: boolean): void
+Configures whether a the bluetoothAddress (mac address) must be the same for two Beacons to be configured equal. This setting applies to all beacon instances in the same process. Defaults to false for backward compatibility. Useful when all the beacons you are working with have the same UUID, major and minor (they are only uniquely identifiable by their MAC_ADDRESS), otherwise the module will detect all the beacons as if they were only one.
+For more info [take a look at the official docs](https://altbeacon.github.io/android-beacon-library/javadoc/index.html)
+<br />
+<br />
+
 ##### Beacons.getRangedRegions(): promise
 Returns a promise that resolves in an array with the regions being ranged.  
 ```javascript

--- a/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
@@ -64,6 +64,11 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
     }
 
     @ReactMethod
+    public void setHardwareEqualityEnforced(Boolean e) {
+      Beacon.setHardwareEqualityEnforced(e.booleanValue());
+    }
+
+    @ReactMethod
     public void addParser(String parser) {
         mBeaconManager.getBeaconParsers().add(new BeaconParser().setBeaconLayout(parser));
     }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ const tramissionSupport = {
   5: 'NOT_SUPPORTED_CANNOT_GET_ADVERTISER_MULTIPLE_ADVERTISEMENTS'
 }
 
+const setHardwareEqualityEnforced = (e) => {
+  beaconsAndroid.setHardwareEqualityEnforced(e)
+}
+
 const detectIBeacons = () => {
   beaconsAndroid.addParser(PARSER_IBEACON)
 }
@@ -67,6 +71,7 @@ const stopRangingBeaconsInRegion = (regionId, beaconsUUID) => new Promise((resol
 })
 
 module.exports = {
+  setHardwareEqualityEnforced,
   detectIBeacons,
   detectEstimotes,
   detectCustomBeaconLayout,


### PR DESCRIPTION
I was working with this library and when ranging, the module would only detect one of the beacons I had. I realized that all my beacons shared UUID, major and minor so AltBeacons asumed they were the same.
I found out that there was a way to enforce the library to distinguish the beacons based on their mac address.
I added the methods for supporting this.

Thanks for the project.
