### PR TITLE
Updated AltBeacon to 2.9.2 and Added iBeacon Support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,5 +15,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.facebook.react:react-native:0.12.+'
-    compile 'org.altbeacon:android-beacon-library:2.6'
+    compile 'org.altbeacon:android-beacon-library:2.9.2'
 }

--- a/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
@@ -44,6 +44,10 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
         this.mReactContext = reactContext;
         this.mApplicationContext = reactContext.getApplicationContext();
         this.mBeaconManager = BeaconManager.getInstanceForApplication(mApplicationContext);
+        // Detect iBeacons ( http://stackoverflow.com/questions/25027983/is-this-the-correct-layout-to-detect-ibeacons-with-altbeacons-android-beacon-li )
+        this.mBeaconManager.getBeaconParsers().add(
+            new BeaconParser().setBeaconLayout("m:0-3=4c000215,i:4-19,i:20-21,i:22-23,p:24-24")
+        );
         mBeaconManager.bind(this);
     }
 

--- a/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mmazzarolo/beaconsandroid/BeaconsAndroidModule.java
@@ -45,9 +45,7 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
         this.mApplicationContext = reactContext.getApplicationContext();
         this.mBeaconManager = BeaconManager.getInstanceForApplication(mApplicationContext);
         // Detect iBeacons ( http://stackoverflow.com/questions/25027983/is-this-the-correct-layout-to-detect-ibeacons-with-altbeacons-android-beacon-li )
-        this.mBeaconManager.getBeaconParsers().add(
-            new BeaconParser().setBeaconLayout("m:0-3=4c000215,i:4-19,i:20-21,i:22-23,p:24-24")
-        );
+        addParser("m:0-3=4c000215,i:4-19,i:20-21,i:22-23,p:24-24");
         mBeaconManager.bind(this);
     }
 


### PR DESCRIPTION
We were having issue #29 where on Android N (7) where we could do a scan only 5 times every 30 seconds. We found out it's fixed in AltBeacon but this library is using AltBeacon 2.6. So we updated it to 2.9.2 after which it was always returning 0 beacons. 
After a lot of testing we found out it was because you need to setBeaconLayout for iBeacons (I don't know why it wasn't required in AltBeacon 2.6 but now it is). After setting beacon layout it worked perfectly on Android 7.